### PR TITLE
fixed bug with inplace multiplication

### DIFF
--- a/include/matrix/matrix.h
+++ b/include/matrix/matrix.h
@@ -28,6 +28,9 @@ Matrix* mat_create(const float* data, const size_t n_rows, const size_t n_colums
 // generate random values for matrix
 void mat_random(Matrix** mat, const float lower_bound, const float upper_bound);
 
+// fill matrix with a value
+void mat_fill(Matrix** mat, const float value);
+
 // return matrix value at index (r, c)
 float mat_at(const Matrix* mat, const size_t r, const size_t c);
 

--- a/src/main/matrix/matrix.c
+++ b/src/main/matrix/matrix.c
@@ -60,6 +60,12 @@ void mat_random(Matrix** mat, const float lower_bound, const float upper_bound)
 			(*mat)->data[compute_offset(r, c, (*mat)->n_columns)] = util_rand_between(lower_bound, upper_bound);
 }
 
+void mat_fill(Matrix** mat, const float value)
+{
+	for (size_t i = 0; i < (*mat)->n_rows * (*mat)->n_columns; ++i)
+		(*mat)->data[i] = value;
+}
+
 float mat_at(const Matrix* mat, const size_t r, const size_t c)
 {
 	return mat->data[compute_offset(r, c, mat->n_columns)];
@@ -220,6 +226,9 @@ static Matrix* __transpose_trick_parallel(const Matrix* mat1, const Matrix* mat2
 
 static void __transpose_trick_inplace(const Matrix* mat1, const Matrix* mat2, Matrix** target)
 {
+	// reset target to 0 incase user calls this multiple times (this caused a bug in my Perceptron...)
+	mat_fill(target, 0.0f);
+
 	Matrix* mat2_tpose = mat_transpose(mat2);
 
 	Vector* row_vec = NULL;
@@ -244,6 +253,9 @@ static void __transpose_trick_inplace(const Matrix* mat1, const Matrix* mat2, Ma
 
 static void __transpose_trick_inplace_parallel(const Matrix* mat1, const Matrix* mat2, Matrix** target)
 {
+	// reset target to 0 incase user calls this multiple times (this caused a bug in my Perceptron...)
+	mat_fill(target, 0.0f);
+
 	Matrix* mat2_tpose = mat_transpose(mat2);
 
 	Vector* row_vec = NULL;


### PR DESCRIPTION
inplace multiplication was not resetting the target matrix, so if you called it multiple times it would accumulate the previous multiplication's results