### PR TITLE
fixed memory leak in __transpose_trick_inplace

### DIFF
--- a/src/main/driver.c
+++ b/src/main/driver.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+#include "matrix.h"
+
+int main()
+{
+	Matrix* mat = NULL;
+	mat_init(&mat, 4096, 4096);
+	
+	Matrix* mat2 = mat_copy(mat);
+	Matrix* prod = mat_multiply_parallel(mat, mat2);
+
+	mat_free(&mat);
+	mat_free(&mat2);
+	mat_free(&prod);
+
+	return 0;
+}

--- a/src/main/matrix/matrix.c
+++ b/src/main/matrix/matrix.c
@@ -231,12 +231,6 @@ static void __transpose_trick_inplace(const Matrix* mat1, const Matrix* mat2, Ma
 
 	Matrix* mat2_tpose = mat_transpose(mat2);
 
-	Vector* row_vec = NULL;
-	vec_init(&row_vec, mat1->n_rows);
-
-	Vector* col_vec = NULL;
-	vec_init(&col_vec, mat2_tpose->n_rows); // due to transpose, the size will be similar to row_vec
-
 	for (size_t r = 0; r < (*target)->n_rows; ++r)
 	{
 		for (size_t c = 0; c < (*target)->n_columns; ++c)


### PR DESCRIPTION
There were unused vectors (artifact from old version) that were being allocated but not needed (and not being freed)